### PR TITLE
docs: raise deep research timeout examples

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -52,6 +52,7 @@ Add this to your MCP client configuration (e.g., `claude_desktop_config.json`, `
   "mcpServers": {
     "perplexity": {
       "command": "perplexity-webui-mcp",
+      "timeout": 600000,
       "env": {
         "PERPLEXITY_SESSION_TOKEN": "YOUR_TOKEN_HERE"
       }
@@ -68,6 +69,7 @@ Add this to your MCP client configuration (e.g., `claude_desktop_config.json`, `
     "perplexity": {
       "command": "node",
       "args": ["/path/to/perplexity-webui-mcp/dist/index.js"],
+      "timeout": 600000,
       "env": {
         "PERPLEXITY_SESSION_TOKEN": "YOUR_TOKEN_HERE"
       }
@@ -107,6 +109,7 @@ systemctl --user enable --now perplexity-webui-mcp.service
       "type": "remote",
       "url": "http://<tailscale-ip>:8790/sse",
       "enabled": true,
+      "timeout": 600000,
       "oauth": false
     }
   }

--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ you can run that command from any directory.
 
 because this server uses `stdio`, you configure it as a local command and pass the token via `env`.
 
+note: deep research can take longer than 60 seconds. if your client supports it, set a higher `timeout` (example: 10 minutes).
+
 **mcp client config (claude desktop, opencode, etc)**
 
 ```json
@@ -108,6 +110,7 @@ because this server uses `stdio`, you configure it as a local command and pass t
   "mcpServers": {
     "perplexity": {
       "command": "perplexity-webui-mcp",
+      "timeout": 600000,
       "env": {
         "PERPLEXITY_SESSION_TOKEN": "your_session_token_here"
       }
@@ -124,6 +127,7 @@ because this server uses `stdio`, you configure it as a local command and pass t
     "perplexity": {
       "command": "node",
       "args": ["/path/to/perplexity-webui-mcp/dist/index.js"],
+      "timeout": 600000,
       "env": {
         "PERPLEXITY_SESSION_TOKEN": "your_session_token_here"
       }
@@ -163,6 +167,7 @@ systemctl --user enable --now perplexity-webui-mcp.service
       "type": "remote",
       "url": "http://<tailscale-ip>:8790/sse",
       "enabled": true,
+      "timeout": 600000,
       "oauth": false
     }
   }


### PR DESCRIPTION
## Why
Deep research queries often exceed the default 60s MCP request timeout, causing `McpError: Request timed out` in clients.

## What changed
- Add `timeout: 600000` (10 minutes) to config examples in `README.md` and `INSTALL.md`.
- Note that deep research can take longer than 60 seconds.

## Notes
This is client-side only (MCP client request timeout), not a change to Perplexity itself.