### PR TITLE
[nightshift] api-contract-verify: fix exports map, deduplicate constants, harden entry guard

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,12 @@
   "description": "MCP wrapper around perplexity-webui-scraper for Perplexity WebUI access",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    }
+  },
   "files": [
     "dist",
     "deploy",

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,13 @@
+/**
+ * Shared constants for perplexity-webui-mcp.
+ *
+ * Centralised here so that `index.ts` and `self-test.ts` reference the
+ * same default upstream package spec.
+ */
+
+export const UPSTREAM_FROM =
+  process.env.PERPLEXITY_UPSTREAM_FROM ??
+  "perplexity-webui-scraper[mcp]@git+https://github.com/henrique-coder/perplexity-webui-scraper.git@prod";
+
+export const UPSTREAM_COMMAND =
+  process.env.PERPLEXITY_UPSTREAM_COMMAND ?? "perplexity-webui-scraper-mcp";

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,7 @@
 
 import { spawn } from "node:child_process";
 import { pathToFileURL } from "node:url";
-
-const UPSTREAM_FROM =
-  process.env.PERPLEXITY_UPSTREAM_FROM ??
-  "perplexity-webui-scraper[mcp]@git+https://github.com/henrique-coder/perplexity-webui-scraper.git@prod";
-const UPSTREAM_COMMAND =
-  process.env.PERPLEXITY_UPSTREAM_COMMAND ?? "perplexity-webui-scraper-mcp";
+import { UPSTREAM_FROM, UPSTREAM_COMMAND } from "./constants.js";
 const HTTP_PROXY_KEYS = ["HTTP_PROXY", "http_proxy"] as const;
 const HTTPS_PROXY_KEYS = ["HTTPS_PROXY", "https_proxy"] as const;
 const ALL_PROXY_KEYS = ["ALL_PROXY", "all_proxy"] as const;
@@ -157,8 +152,24 @@ function main(): void {
   forwardSignal("SIGTERM");
 }
 
-const currentEntryPoint = process.argv[1];
+// Robust entry guard: only run main() when executed directly as a script,
+// not when imported as a module. Checks both process.argv[1] match and
+// whether we're being run via the npm bin entry point.
+const isDirectRun = (() => {
+  try {
+    const entry = process.argv[1];
+    if (!entry) return false;
+    const entryUrl = pathToFileURL(entry).href;
+    if (import.meta.url === entryUrl) return true;
+    // Also match when run via npx or globally linked bin (resolved paths)
+    const entryPath = new URL(entryUrl).pathname;
+    const modulePath = new URL(import.meta.url).pathname;
+    return entryPath.endsWith("dist/index.js") && modulePath.endsWith("dist/index.js") && process.argv[1]?.includes("perplexity-webui-mcp");
+  } catch {
+    return false;
+  }
+})();
 
-if (currentEntryPoint && import.meta.url === pathToFileURL(currentEntryPoint).href) {
+if (isDirectRun) {
   main();
 }

--- a/src/self-test.ts
+++ b/src/self-test.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 
 import { spawnSync } from "node:child_process";
+import { UPSTREAM_FROM } from "./constants.js";
 
 type ModeResult = {
   ok: boolean;
@@ -13,10 +14,6 @@ type TestResult = {
   regular: ModeResult;
   deep_research: ModeResult;
 };
-
-const UPSTREAM_FROM =
-  process.env.PERPLEXITY_UPSTREAM_FROM ??
-  "perplexity-webui-scraper[mcp]@git+https://github.com/henrique-coder/perplexity-webui-scraper.git@prod";
 
 function fail(message: string): never {
   console.error(`perplexity-webui-mcp self-test: ${message}`);


### PR DESCRIPTION
Automated by Nightshift v3 (GLM 5.1).

**Task:** API Contract Verification
**Category:** PR
**Changes:**

1. **Add explicit `exports` field to package.json** — modern Node.js resolution now has a proper exports map instead of relying solely on `main`/`types`.

2. **Extract shared constants to `src/constants.ts`** — `UPSTREAM_FROM` and `UPSTREAM_COMMAND` were duplicated between `index.ts` and `self-test.ts`. A single source of truth prevents drift between the main module and the self-test runner.

3. **Harden entry-point guard** — the original guard (`process.argv[1] === import.meta.url`) fails when run via `npx` or as a globally linked bin. The new guard handles these scenarios while still preventing `main()` from executing on import.

All changes compile clean with `tsc --noEmit`.

Merge if useful, close if not.