### PR TITLE
feat: add flaresolverr fallback for cloudflare challenges

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -55,6 +55,10 @@ Proxy note:
 - if you already use standard proxy env vars such as `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, or `NO_PROXY`, the wrapper forwards them to the upstream process
 - if you want one wrapper-specific knob, set `PERPLEXITY_PROXY_URL`; it is expanded into the standard proxy env vars before the upstream MCP server starts
 - use `PERPLEXITY_NO_PROXY` for bypass hosts
+- if your host gets stuck on Cloudflare challenge pages, run FlareSolverr and set `PERPLEXITY_FLARESOLVERR_URL`; the wrapper will solve `https://www.perplexity.ai/search/new` first and inject the resulting cookies into the upstream session
+- optional FlareSolverr overrides:
+  - `PERPLEXITY_FLARESOLVERR_SOLVE_URL` - alternate URL to solve first. default: `https://www.perplexity.ai/search/new`
+  - `PERPLEXITY_FLARESOLVERR_MAX_TIMEOUT` - FlareSolverr solve timeout in milliseconds. default: `60000`
 
 **If installed via npm:**
 
@@ -66,8 +70,7 @@ Proxy note:
       "timeout": 600000,
       "env": {
         "PERPLEXITY_SESSION_TOKEN": "YOUR_TOKEN_HERE",
-        "PERPLEXITY_PROXY_URL": "socks5://127.0.0.1:1080",
-        "PERPLEXITY_NO_PROXY": "localhost,127.0.0.1"
+        "PERPLEXITY_FLARESOLVERR_URL": "http://127.0.0.1:8191"
       }
     }
   }
@@ -85,13 +88,40 @@ Proxy note:
       "timeout": 600000,
       "env": {
         "PERPLEXITY_SESSION_TOKEN": "YOUR_TOKEN_HERE",
-        "PERPLEXITY_PROXY_URL": "socks5://127.0.0.1:1080",
-        "PERPLEXITY_NO_PROXY": "localhost,127.0.0.1"
+        "PERPLEXITY_FLARESOLVERR_URL": "http://127.0.0.1:8191"
       }
     }
   }
 }
 ```
+
+### Optional: use FlareSolverr for Cloudflare-challenged hosts
+
+Start FlareSolverr locally:
+
+```bash
+docker run -d --name flaresolverr -p 8191:8191 ghcr.io/flaresolverr/flaresolverr:latest
+curl http://127.0.0.1:8191/
+```
+
+Then point the wrapper at it:
+
+```json
+{
+  "mcpServers": {
+    "perplexity": {
+      "command": "perplexity-webui-mcp",
+      "timeout": 600000,
+      "env": {
+        "PERPLEXITY_SESSION_TOKEN": "YOUR_TOKEN_HERE",
+        "PERPLEXITY_FLARESOLVERR_URL": "http://127.0.0.1:8191"
+      }
+    }
+  }
+}
+```
+
+In this mode the wrapper does not forward `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, or `NO_PROXY` to the upstream process. The solved cookies need to stay tied to the FlareSolverr browser route.
 
 ### 4. Restart your MCP client
 
@@ -153,6 +183,7 @@ PERPLEXITY_SESSION_TOKEN="YOUR_TOKEN_HERE" npm run self-test
 | Command not found | Run `npm install -g perplexity-webui-mcp` again |
 | `uvx` not found | Install uv and ensure `uvx --version` works |
 | No answer returned | Check rate limits or whether your account can access selected model |
+| Cloudflare challenge / `Just a moment...` | Run FlareSolverr and set `PERPLEXITY_FLARESOLVERR_URL=http://127.0.0.1:8191` |
 | Timeout | Deep research can take several minutes - be patient |
 
 ## Acknowledgment
@@ -167,3 +198,6 @@ This project was built with help from:
 | `PERPLEXITY_SESSION_TOKEN` | Yes | Your `__Secure-next-auth.session-token` cookie value |
 | `PERPLEXITY_PROXY_URL` | No | Single proxy URL expanded into `HTTP_PROXY`, `HTTPS_PROXY`, and `ALL_PROXY` for the upstream process |
 | `PERPLEXITY_NO_PROXY` | No | Optional bypass list expanded into `NO_PROXY` |
+| `PERPLEXITY_FLARESOLVERR_URL` | No | Base URL for a running FlareSolverr instance, for example `http://127.0.0.1:8191` |
+| `PERPLEXITY_FLARESOLVERR_SOLVE_URL` | No | Alternate Perplexity URL to solve before the upstream client starts. default: `https://www.perplexity.ai/search/new` |
+| `PERPLEXITY_FLARESOLVERR_MAX_TIMEOUT` | No | FlareSolverr solve timeout in milliseconds. default: `60000` |

--- a/README.md
+++ b/README.md
@@ -48,13 +48,23 @@ PERPLEXITY_PROXY_URL="socks5://127.0.0.1:1080" \
 npx perplexity-webui-mcp
 ```
 
+manual run with flaresolverr:
+
+```bash
+docker run -d --name flaresolverr -p 8191:8191 ghcr.io/flaresolverr/flaresolverr:latest
+
+PERPLEXITY_SESSION_TOKEN="your_token_here" \
+PERPLEXITY_FLARESOLVERR_URL="http://127.0.0.1:8191" \
+npx perplexity-webui-mcp
+```
+
 > **important:** this uses perplexity's internal webui api with a session cookie. for personal/local tinkering only - not affiliated with perplexity ai.
 
 ---
 
 ### overview
 
-perplexity-webui-mcp is a local stdio MCP wrapper that launches the upstream `perplexity-webui-scraper` MCP server through `uvx`. this keeps your package on npm while using the upstream battle-tested WebUI implementation (browser impersonation, retry logic, model-specific tools, and token CLI ecosystem).
+perplexity-webui-mcp is a local stdio mcp wrapper that launches the upstream `perplexity-webui-scraper` mcp server through `uvx`. this keeps the package on npm while using the upstream webui implementation for browser impersonation, retry logic, model-specific tools, and token tooling.
 
 ---
 
@@ -127,6 +137,10 @@ proxy support:
 - standard proxy env vars already pass through: `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY` and their lowercase variants
 - for a simpler single-value setup, set `PERPLEXITY_PROXY_URL`; the wrapper expands it into the standard proxy env vars before launching the upstream MCP server
 - optional bypass list: `PERPLEXITY_NO_PROXY`
+- if perplexity keeps returning cloudflare challenge pages, set `PERPLEXITY_FLARESOLVERR_URL` to a running flaresolverr instance. the wrapper solves `https://www.perplexity.ai/search/new`, injects the returned cookies into the upstream `curl_cffi` session, and stops forwarding the standard proxy env vars in that mode
+- optional flaresolverr overrides:
+  - `PERPLEXITY_FLARESOLVERR_SOLVE_URL` - alternate url to solve first. default: `https://www.perplexity.ai/search/new`
+  - `PERPLEXITY_FLARESOLVERR_MAX_TIMEOUT` - flaresolverr solve timeout in milliseconds. default: `60000`
 
 note: deep research can take longer than 60 seconds. if your client supports it, set a higher `timeout` (example: 10 minutes).
 
@@ -140,8 +154,7 @@ note: deep research can take longer than 60 seconds. if your client supports it,
       "timeout": 600000,
       "env": {
         "PERPLEXITY_SESSION_TOKEN": "your_session_token_here",
-        "PERPLEXITY_PROXY_URL": "socks5://127.0.0.1:1080",
-        "PERPLEXITY_NO_PROXY": "localhost,127.0.0.1"
+        "PERPLEXITY_FLARESOLVERR_URL": "http://127.0.0.1:8191"
       }
     }
   }
@@ -159,13 +172,34 @@ note: deep research can take longer than 60 seconds. if your client supports it,
       "timeout": 600000,
       "env": {
         "PERPLEXITY_SESSION_TOKEN": "your_session_token_here",
-        "PERPLEXITY_PROXY_URL": "socks5://127.0.0.1:1080",
-        "PERPLEXITY_NO_PROXY": "localhost,127.0.0.1"
+        "PERPLEXITY_FLARESOLVERR_URL": "http://127.0.0.1:8191"
       }
     }
   }
 }
 ```
+
+### using flaresolverr when cloudflare blocks your host
+
+start flaresolverr:
+
+```bash
+docker run -d --name flaresolverr -p 8191:8191 ghcr.io/flaresolverr/flaresolverr:latest
+curl http://127.0.0.1:8191/
+```
+
+then point the wrapper at it:
+
+```bash
+PERPLEXITY_SESSION_TOKEN="your_token_here" \
+PERPLEXITY_FLARESOLVERR_URL="http://127.0.0.1:8191" \
+npx perplexity-webui-mcp
+```
+
+flaresolverr mode:
+- the wrapper solves the cloudflare wall in flaresolverr first, then injects the returned cookies into the upstream session
+- the wrapper does not forward `HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, or `NO_PROXY` to the upstream process in this mode because the solved cookies need to stay tied to the flaresolverr browser route
+- if flaresolverr itself needs a proxy, configure that on the flaresolverr side instead of on `perplexity-webui-mcp`
 
 ### remote deployment over tailscale (optional)
 
@@ -246,6 +280,7 @@ all upstream model tools support `source_focus` values: `web`, `academic`, `soci
 | **`uvx` not found** | install uv (`uv --version` should work) |
 | **no answer returned** | check rate limits or whether your account can access the selected model |
 | **clarifying questions error** | deep research mode may request clarifying questions first |
+| **cloudflare challenge / `Just a moment...`** | run flaresolverr and set `PERPLEXITY_FLARESOLVERR_URL=http://127.0.0.1:8191` |
 | **timeout** | deep research can take several minutes - be patient |
 
 ### verify both modes quickly

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "perplexity-webui-mcp",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "perplexity-webui-mcp",
-      "version": "2.0.1",
+      "version": "2.1.0",
       "license": "MIT",
       "bin": {
         "perplexity-webui-mcp": "dist/index.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "perplexity-webui-mcp",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "MCP wrapper around perplexity-webui-scraper for Perplexity WebUI access",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 
-import { buildChildEnv } from "./index.js";
+import { buildChildEnv, buildRunnerArgs, shouldUseFlareSolverr } from "./index.js";
 
 test("buildChildEnv mirrors explicit proxy env vars across upper and lower case", () => {
   const childEnv = buildChildEnv({
@@ -49,4 +49,45 @@ test("buildChildEnv does not override already-set standard proxy env vars", () =
   assert.equal(childEnv.https_proxy, "http://existing-https:8443");
   assert.equal(childEnv.ALL_PROXY, "socks5://existing-all:1080");
   assert.equal(childEnv.all_proxy, "socks5://existing-all:1080");
+});
+
+test("buildChildEnv strips proxy env vars when FlareSolverr mode is enabled", () => {
+  const childEnv = buildChildEnv({
+    PERPLEXITY_SESSION_TOKEN: "token-value",
+    PERPLEXITY_FLARESOLVERR_URL: " http://127.0.0.1:8191 ",
+    PERPLEXITY_FLARESOLVERR_SOLVE_URL: " https://www.perplexity.ai/search/new ",
+    PERPLEXITY_FLARESOLVERR_MAX_TIMEOUT: " 90000 ",
+    HTTP_PROXY: "http://existing-http:8080",
+    HTTPS_PROXY: "http://existing-https:8443",
+    ALL_PROXY: "socks5://existing-all:1080",
+    NO_PROXY: "localhost,.internal",
+  });
+
+  assert.equal(childEnv.PERPLEXITY_FLARESOLVERR_URL, "http://127.0.0.1:8191");
+  assert.equal(
+    childEnv.PERPLEXITY_FLARESOLVERR_SOLVE_URL,
+    "https://www.perplexity.ai/search/new",
+  );
+  assert.equal(childEnv.PERPLEXITY_FLARESOLVERR_MAX_TIMEOUT, "90000");
+  assert.equal(childEnv.HTTP_PROXY, undefined);
+  assert.equal(childEnv.HTTPS_PROXY, undefined);
+  assert.equal(childEnv.ALL_PROXY, undefined);
+  assert.equal(childEnv.NO_PROXY, undefined);
+});
+
+test("FlareSolverr mode switches the wrapper to the python bridge", () => {
+  assert.equal(shouldUseFlareSolverr({}), false);
+  assert.equal(
+    shouldUseFlareSolverr({ PERPLEXITY_FLARESOLVERR_URL: "http://127.0.0.1:8191" }),
+    true,
+  );
+
+  const args = buildRunnerArgs({
+    PERPLEXITY_FLARESOLVERR_URL: "http://127.0.0.1:8191",
+  });
+
+  assert.equal(args[0], "--from");
+  assert.equal(args[2], "python");
+  assert.equal(args[3], "-c");
+  assert.match(args[4] ?? "", /maybe_enable_flaresolverr/);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,115 @@
 #!/usr/bin/env node
 
-import { spawn } from "node:child_process";
-import { pathToFileURL } from "node:url";
+import childProcess from "node:child_process";
+import nodeUrl from "node:url";
 
 const UPSTREAM_FROM =
   process.env.PERPLEXITY_UPSTREAM_FROM ??
   "perplexity-webui-scraper[mcp]@git+https://github.com/henrique-coder/perplexity-webui-scraper.git@prod";
 const UPSTREAM_COMMAND =
   process.env.PERPLEXITY_UPSTREAM_COMMAND ?? "perplexity-webui-scraper-mcp";
+const FLARESOLVERR_URL_KEY = "PERPLEXITY_FLARESOLVERR_URL";
+const FLARESOLVERR_SOLVE_URL_KEY = "PERPLEXITY_FLARESOLVERR_SOLVE_URL";
+const FLARESOLVERR_TIMEOUT_KEY = "PERPLEXITY_FLARESOLVERR_MAX_TIMEOUT";
 const HTTP_PROXY_KEYS = ["HTTP_PROXY", "http_proxy"] as const;
 const HTTPS_PROXY_KEYS = ["HTTPS_PROXY", "https_proxy"] as const;
 const ALL_PROXY_KEYS = ["ALL_PROXY", "all_proxy"] as const;
 const NO_PROXY_KEYS = ["NO_PROXY", "no_proxy"] as const;
+const FLARESOLVERR_DEFAULT_UA =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/142.0.0.0 Safari/537.36";
+
+export function buildFlareSolverrPythonBootstrap(): string {
+  return String.raw`
+import json
+import os
+import urllib.request
+
+from perplexity_webui_scraper.constants import API_BASE_URL, DEFAULT_HEADERS, SESSION_COOKIE_NAME
+from perplexity_webui_scraper.http import HTTPClient
+
+DEFAULT_FLARESOLVERR_UA = ${JSON.stringify(FLARESOLVERR_DEFAULT_UA)}
+
+
+def maybe_enable_flaresolverr():
+    flaresolverr_url = os.environ.get(${JSON.stringify(FLARESOLVERR_URL_KEY)}, "").strip()
+
+    if not flaresolverr_url:
+        return
+
+    solve_url = os.environ.get(
+        ${JSON.stringify(FLARESOLVERR_SOLVE_URL_KEY)},
+        "https://www.perplexity.ai/search/new",
+    ).strip()
+    max_timeout_raw = os.environ.get(${JSON.stringify(FLARESOLVERR_TIMEOUT_KEY)}, "60000").strip()
+
+    try:
+        max_timeout = int(max_timeout_raw)
+    except ValueError as error:
+        raise RuntimeError(
+            f"${FLARESOLVERR_TIMEOUT_KEY} must be an integer number of milliseconds: {max_timeout_raw}"
+        ) from error
+
+    request = urllib.request.Request(
+        f"{flaresolverr_url.rstrip('/')}/v1",
+        data=json.dumps({
+            "cmd": "request.get",
+            "url": solve_url,
+            "maxTimeout": max_timeout,
+        }).encode(),
+        headers={"Content-Type": "application/json"},
+    )
+
+    timeout_seconds = max(60.0, max_timeout / 1000 + 30.0)
+
+    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
+        data = json.load(response)
+
+    if data.get("status") != "ok":
+        raise RuntimeError(
+            f"FlareSolverr request failed: {data.get('message') or data}"
+        )
+
+    solution = data.get("solution") or {}
+    cookies = solution.get("cookies") or []
+
+    if not cookies:
+        raise RuntimeError("FlareSolverr returned no cookies for Perplexity")
+
+    solved_cookies = {
+        cookie["name"]: cookie["value"]
+        for cookie in cookies
+        if cookie.get("name") and cookie.get("value")
+    }
+
+    if not solved_cookies:
+        raise RuntimeError("FlareSolverr returned cookies, but none had usable values")
+
+    user_agent = solution.get("userAgent") or DEFAULT_FLARESOLVERR_UA
+    original_create_session = HTTPClient._create_session
+
+    # Cloudflare ties the clearance cookies to the browser route that solved them.
+    def patched_create_session(self, impersonate):
+        session = original_create_session(self, impersonate)
+        session.headers["User-Agent"] = user_agent
+
+        for name, value in solved_cookies.items():
+            session.cookies.set(name, value)
+
+        return session
+
+    HTTPClient._create_session = patched_create_session
+`;
+}
+
+const FLARESOLVERR_MCP_SCRIPT = String.raw`
+${buildFlareSolverrPythonBootstrap()}
+
+maybe_enable_flaresolverr()
+
+from perplexity_webui_scraper.mcp.server import mcp
+
+mcp.run()
+`;
 
 function fail(message: string): never {
   console.error(`perplexity-webui-mcp: ${message}`);
@@ -48,6 +146,22 @@ function setMirroredValue({
   });
 }
 
+function clearMirroredValue({
+  env,
+  keys,
+}: {
+  env: NodeJS.ProcessEnv;
+  keys: readonly string[];
+}): void {
+  keys.forEach((key) => {
+    delete env[key];
+  });
+}
+
+export function shouldUseFlareSolverr(env: NodeJS.ProcessEnv): boolean {
+  return Boolean(env[FLARESOLVERR_URL_KEY]?.trim());
+}
+
 export function buildChildEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const childEnv: NodeJS.ProcessEnv = {
     ...env,
@@ -56,6 +170,32 @@ export function buildChildEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   const token = env.PERPLEXITY_SESSION_TOKEN?.trim();
   if (token) {
     childEnv.PERPLEXITY_SESSION_TOKEN = token;
+  }
+
+  const flaresolverrUrl = env[FLARESOLVERR_URL_KEY]?.trim();
+  if (flaresolverrUrl) {
+    childEnv[FLARESOLVERR_URL_KEY] = flaresolverrUrl;
+  }
+
+  const flaresolverrSolveUrl = env[FLARESOLVERR_SOLVE_URL_KEY]?.trim();
+  if (flaresolverrSolveUrl) {
+    childEnv[FLARESOLVERR_SOLVE_URL_KEY] = flaresolverrSolveUrl;
+  }
+
+  const flaresolverrTimeout = env[FLARESOLVERR_TIMEOUT_KEY]?.trim();
+  if (flaresolverrTimeout) {
+    childEnv[FLARESOLVERR_TIMEOUT_KEY] = flaresolverrTimeout;
+  }
+
+  if (flaresolverrUrl) {
+    // FlareSolverr clears the challenge inside its own browser session, so the
+    // upstream client should not reuse an unrelated HTTP/SOCKS proxy route.
+    clearMirroredValue({ env: childEnv, keys: HTTP_PROXY_KEYS });
+    clearMirroredValue({ env: childEnv, keys: HTTPS_PROXY_KEYS });
+    clearMirroredValue({ env: childEnv, keys: ALL_PROXY_KEYS });
+    clearMirroredValue({ env: childEnv, keys: NO_PROXY_KEYS });
+
+    return childEnv;
   }
 
   const proxyUrl = env.PERPLEXITY_PROXY_URL?.trim();
@@ -113,6 +253,14 @@ export function buildChildEnv(env: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
   return childEnv;
 }
 
+export function buildRunnerArgs(env: NodeJS.ProcessEnv): string[] {
+  if (shouldUseFlareSolverr(env)) {
+    return ["--from", UPSTREAM_FROM, "python", "-c", FLARESOLVERR_MCP_SCRIPT];
+  }
+
+  return ["--from", UPSTREAM_FROM, UPSTREAM_COMMAND];
+}
+
 function main(): void {
   const token = process.env.PERPLEXITY_SESSION_TOKEN?.trim();
   if (!token) {
@@ -121,7 +269,7 @@ function main(): void {
     );
   }
 
-  const child = spawn("uvx", ["--from", UPSTREAM_FROM, UPSTREAM_COMMAND], {
+  const child = childProcess.spawn("uvx", buildRunnerArgs(process.env), {
     stdio: "inherit",
     env: buildChildEnv(process.env),
   });
@@ -159,6 +307,6 @@ function main(): void {
 
 const currentEntryPoint = process.argv[1];
 
-if (currentEntryPoint && import.meta.url === pathToFileURL(currentEntryPoint).href) {
+if (currentEntryPoint && import.meta.url === nodeUrl.pathToFileURL(currentEntryPoint).href) {
   main();
 }

--- a/src/self-test.ts
+++ b/src/self-test.ts
@@ -1,6 +1,8 @@
 #!/usr/bin/env node
 
-import { spawnSync } from "node:child_process";
+import childProcess from "node:child_process";
+
+import { buildFlareSolverrPythonBootstrap } from "./index.js";
 
 type ModeResult = {
   ok: boolean;
@@ -64,6 +66,10 @@ from perplexity_webui_scraper import (
   SearchFocus,
   SourceFocus,
 )
+
+${buildFlareSolverrPythonBootstrap()}
+
+maybe_enable_flaresolverr()
 
 token = os.environ.get("PERPLEXITY_SESSION_TOKEN", "").strip()
 result = {
@@ -133,7 +139,7 @@ client.close()
 print(json.dumps(result))
 `;
 
-  const run = spawnSync(
+  const run = childProcess.spawnSync(
     "uvx",
     [
       "--from",


### PR DESCRIPTION
**what changed**
- adds optional `PERPLEXITY_FLARESOLVERR_URL` support for hosts that get stuck on Perplexity Cloudflare challenge pages
- runs the upstream MCP through a small Python bridge that solves `/search/new` in FlareSolverr and injects the returned cookies into the upstream `curl_cffi` session
- stops forwarding standard proxy env vars in FlareSolverr mode so the solved cookies stay on the same browser route
- updates self-test wiring, docs, and package version to `2.1.0`

**verification**
- `npm run typecheck`
- `node --import tsx --test src/index.test.ts`
- `npm run build`

**notes**
- live package self-test was not rerun in this shell because `PERPLEXITY_SESSION_TOKEN` is not set here
- the FlareSolverr path was manually validated earlier in this work by solving the challenge and completing a real `conversation.ask(...)` call through the patched upstream client