### PR TITLE
nightshift: add missing source files to project structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -307,7 +307,9 @@ perplexity-webui-mcp/
 │       ├── perplexity-webui-mcp-sse.sh
 │       └── perplexity-webui-mcp.service
 ├── src/
-│   └── index.ts      # proxy launcher for upstream MCP
+│   ├── index.ts        # proxy launcher for upstream MCP
+│   ├── index.test.ts   # unit tests for env/arg builders
+│   └── self-test.ts    # integration self-test (regular + deep research)
 ├── package.json
 ├── tsconfig.json
 ├── .env.example


### PR DESCRIPTION
## Summary

The project structure section in README.md only listed `index.ts` under `src/`, but the directory also contains:

- **`index.test.ts`** — unit tests for env/arg builders
- **`self-test.ts`** — integration self-test (regular + deep research modes)

Both files are now documented with descriptions.

## Categories
- docs

---
*Automated by [nightshift](https://github.com/Microck/hermes-nightshift-glm) — readme-improvements task*